### PR TITLE
Fixes to warnings

### DIFF
--- a/radstract/visuals/report_generator.py
+++ b/radstract/visuals/report_generator.py
@@ -177,7 +177,7 @@ class ReportGenerator:
         # Create highlights container
         highlights_html = f'<div style="background-color: {self.background_color_light}; border-radius: 8px; padding: 12px; margin: 20px 0; border: 1px solid {self.border_color};">'
         highlights_html += f'<h3 style="color: {self.accent_color}; font-family: Arial Black, Arial, sans-serif; font-size: 16px; margin: 3px 0 8px 0; border-bottom: 2px solid {self.accent_color}; padding-bottom: 3px;">Highlights</h3>'
-        highlights_html += f'<div style="display: flex; flex-direction: row; gap: 8px; flex-wrap: nowrap; overflow-x: auto; justify-content: center;">'
+        highlights_html += f'<div style="display: flex; flex-direction: row; gap: 8px; flex-wrap: nowrap; justify-content: center;">'
 
         # Add success/failure indicator
         success_icon = "✓" if report_success else "✗"
@@ -324,7 +324,7 @@ class ReportGenerator:
         :param data: Dictionary or list of data
         :param title: Title for the JSON block
         """
-        json_html = f'<div style="background-color: {self.background_color_light}; border: 1px solid {self.border_color}; border-radius: 6px; padding: 15px; margin: 15px 0; overflow-x: auto;">'
+        json_html = f'<div style="background-color: {self.background_color_light}; border: 1px solid {self.border_color}; border-radius: 6px; padding: 15px; margin: 15px 0;">'
 
         if title:
             json_html += f'<h4 style="color: {self.accent_color}; margin: 0 0 10px 0; font-family: Arial Black, Arial, sans-serif;">{title}</h4>'

--- a/radstract/visuals/report_utils.py
+++ b/radstract/visuals/report_utils.py
@@ -15,6 +15,23 @@
 import os
 
 
+def hex_to_rgba(hex_color: str, alpha: float) -> str:
+    """Convert a hex color like '#00ff00' to an rgba() CSS string."""
+    # Remove '#' if present
+    hex_color = hex_color.lstrip("#")
+
+    # Handle short hex like #0f0
+    if len(hex_color) == 3:
+        hex_color = "".join([c * 2 for c in hex_color])
+
+    # Convert hex to RGB
+    r = int(hex_color[0:2], 16)
+    g = int(hex_color[2:4], 16)
+    b = int(hex_color[4:6], 16)
+
+    return f"rgba({r}, {g}, {b}, {alpha})"
+
+
 def generate_css_styles(
     accent_color: str,
     header_color: str,
@@ -184,7 +201,7 @@ def create_highlight_box(
     """
     return f"""
         <div style="display: flex; align-items: center; justify-content: center; background-color: {background_color}; padding: 8px; border-radius: 6px; border: 1px solid {border_color}; min-width: 140px; flex: 1;">
-            <div style="width: 30px; height: 30px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 20px; font-weight: bold; margin-right: 8px; flex-shrink: 0; background-color: rgba({icon_color}, 0.2); color: {icon_color}; border: 2px solid {icon_color};">
+            <div style="width: 30px; height: 30px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 20px; font-weight: bold; margin-right: 8px; flex-shrink: 0; background-color: {hex_to_rgba(icon_color, 0.2)}; color: {icon_color}; border: 2px solid {icon_color};">
                 {icon}
             </div>
             <div style="flex: 1; min-width: 0; text-align: center;">


### PR DESCRIPTION
```
-----------------------------------------------------------------------
TOTAL                                                1186    269    77%

==================================== slowest 5 durations =====================================
3.10s call     tests/unit/analysis/test_shapedistro_plot.py::test_generate_comparison_plot
1.62s call     tests/unit/analysis/test_shapedistro_plot.py::test_get_plot_data
1.09s call     tests/unit/data/test_dicom.py::test_convert_dicom_to_images
0.59s call     tests/unit/visuals/test_dicom_pdf_generation.py::TestDicomPdfGeneration::test_save_to_dicom_study_with_default_parameters
0.52s call     tests/unit/data/test_niftis.py::test_convert_nifti_to_image_labels_with_compression
============================== 77 passed, 3 warnings in 13.03s ==============================
```